### PR TITLE
Set up SignalR hub and chat page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # Ass03Solution
+
+## SignalR Support
+
+This project now includes a basic SignalR setup with a `ChatHub` and a `Chat`
+page demonstrating real-time communication. The hub is available at `/chatHub`
+and the chat UI can be reached by navigating to `/chat` when the application is
+running.

--- a/eStore/Components/Layout/NavMenu.razor
+++ b/eStore/Components/Layout/NavMenu.razor
@@ -25,6 +25,12 @@
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Weather
             </NavLink>
         </div>
+
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="chat">
+                <span class="bi bi-chat-nav-menu" aria-hidden="true"></span> Chat
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/eStore/Components/Pages/Chat.razor
+++ b/eStore/Components/Pages/Chat.razor
@@ -1,0 +1,58 @@
+@page "/chat"
+@rendermode InteractiveServer
+@using Microsoft.AspNetCore.SignalR.Client
+@inject NavigationManager NavigationManager
+
+<PageTitle>Chat</PageTitle>
+
+<h1>Chat</h1>
+
+<div class="mb-2">
+    <input @bind="userInput" placeholder="Name" class="form-control mb-1" />
+    <input @bind="messageInput" placeholder="Message" class="form-control mb-1" />
+    <button class="btn btn-primary" @onclick="SendMessage" disabled="@(hubConnection?.State != HubConnectionState.Connected)">Send</button>
+</div>
+
+<ul>
+    @foreach (var message in messages)
+    {
+        <li><b>@message.User:</b> @message.Text</li>
+    }
+</ul>
+
+@code {
+    private HubConnection? hubConnection;
+    private string? userInput;
+    private string? messageInput;
+    private List<ChatMessage> messages = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        hubConnection = new HubConnectionBuilder()
+            .WithUrl(NavigationManager.ToAbsoluteUri("/chatHub"))
+            .WithAutomaticReconnect()
+            .Build();
+
+        hubConnection.On<string, string>("ReceiveMessage", (user, message) =>
+        {
+            messages.Add(new ChatMessage { User = user, Text = message });
+            InvokeAsync(StateHasChanged);
+        });
+
+        await hubConnection.StartAsync();
+    }
+
+    private async Task SendMessage()
+    {
+        if (hubConnection is not null)
+        {
+            await hubConnection.SendAsync("SendMessage", userInput, messageInput);
+        }
+    }
+
+    private class ChatMessage
+    {
+        public string? User { get; set; }
+        public string? Text { get; set; }
+    }
+}

--- a/eStore/Hubs/ChatHub.cs
+++ b/eStore/Hubs/ChatHub.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace eStore.Hubs
+{
+    public class ChatHub : Hub
+    {
+        public async Task SendMessage(string user, string message)
+        {
+            await Clients.All.SendAsync("ReceiveMessage", user, message);
+        }
+    }
+}

--- a/eStore/Program.cs
+++ b/eStore/Program.cs
@@ -8,6 +8,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
+builder.Services.AddSignalR();
 
 // Register AppDbContext with DI
 builder.Services.AddDbContext<AppDbContext>(options =>
@@ -27,6 +28,7 @@ app.UseStaticFiles();
 app.UseRouting();
 
 app.MapBlazorHub();
+app.MapHub<eStore.Hubs.ChatHub>("/chatHub");
 app.MapFallbackToPage("/_Host");
 
 app.Run();

--- a/eStore/eStore.csproj
+++ b/eStore/eStore.csproj
@@ -12,6 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- enable SignalR services in Program.cs
- add ChatHub
- create Chat page to demonstrate SignalR usage
- link Chat page from navigation
- reference SignalR client package
- document SignalR support in README

## Testing
- `dotnet build Asm03Solution.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f61377ff4832db2f558bd1a61ff11