### PR TITLE
Add admin login functionality

### DIFF
--- a/eStore/AdminAccount.cs
+++ b/eStore/AdminAccount.cs
@@ -1,0 +1,8 @@
+namespace eStore
+{
+    public class AdminAccount
+    {
+        public string Email { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+    }
+}

--- a/eStore/AdminAuthService.cs
+++ b/eStore/AdminAuthService.cs
@@ -1,0 +1,17 @@
+namespace eStore
+{
+    public class AdminAuthService
+    {
+        public bool IsLoggedIn { get; private set; }
+
+        public void SignIn()
+        {
+            IsLoggedIn = true;
+        }
+
+        public void SignOut()
+        {
+            IsLoggedIn = false;
+        }
+    }
+}

--- a/eStore/AdminAuthService.cs
+++ b/eStore/AdminAuthService.cs
@@ -4,9 +4,16 @@ namespace eStore
     {
         public bool IsLoggedIn { get; private set; }
 
-        public void SignIn()
+        public bool Login(string email, string password, AdminAccount account)
         {
-            IsLoggedIn = true;
+            if (string.Equals(email.Trim(), account.Email, System.StringComparison.OrdinalIgnoreCase)
+                && password == account.Password)
+            {
+                IsLoggedIn = true;
+                return true;
+            }
+
+            return false;
         }
 
         public void SignOut()

--- a/eStore/Components/Layout/NavMenu.razor
+++ b/eStore/Components/Layout/NavMenu.razor
@@ -25,6 +25,12 @@
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Weather
             </NavLink>
         </div>
+
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="login">
+                <span class="bi bi-door-open" aria-hidden="true"></span> Login
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/eStore/Components/Pages/Login.razor
+++ b/eStore/Components/Pages/Login.razor
@@ -1,0 +1,61 @@
+@page "/login"
+@inject Microsoft.Extensions.Options.IOptions<eStore.AdminAccount> AdminOptions
+@inject eStore.AdminAuthService AuthService
+@inject Microsoft.AspNetCore.Components.NavigationManager Navigation
+
+<PageTitle>Login</PageTitle>
+
+@if (AuthService.IsLoggedIn)
+{
+    <p>You are logged in.</p>
+    <button class="btn btn-secondary" @onclick="Logout">Logout</button>
+}
+else
+{
+    <EditForm Model="loginModel" OnValidSubmit="HandleLogin">
+        <DataAnnotationsValidator />
+        @if (!string.IsNullOrEmpty(error))
+        {
+            <div class="text-danger">@error</div>
+        }
+        <div class="mb-3">
+            <label for="email" class="form-label">Email</label>
+            <InputText id="email" class="form-control" @bind-Value="loginModel.Email" />
+        </div>
+        <div class="mb-3">
+            <label for="password" class="form-label">Password</label>
+            <InputText id="password" type="password" class="form-control" @bind-Value="loginModel.Password" />
+        </div>
+        <button type="submit" class="btn btn-primary">Login</button>
+    </EditForm>
+}
+
+@code {
+    private LoginModel loginModel = new();
+    private string? error;
+
+    private void HandleLogin()
+    {
+        var admin = AdminOptions.Value;
+        if (loginModel.Email == admin.Email && loginModel.Password == admin.Password)
+        {
+            AuthService.SignIn();
+            Navigation.NavigateTo("/");
+        }
+        else
+        {
+            error = "Invalid credentials";
+        }
+    }
+
+    private void Logout()
+    {
+        AuthService.SignOut();
+    }
+
+    private class LoginModel
+    {
+        public string Email { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+    }
+}

--- a/eStore/Components/Pages/Login.razor
+++ b/eStore/Components/Pages/Login.razor
@@ -38,10 +38,8 @@ else
     private void HandleLogin()
     {
         var admin = AdminOptions.Value;
-        if (string.Equals(loginModel.Email?.Trim(), admin.Email, System.StringComparison.OrdinalIgnoreCase)
-            && loginModel.Password == admin.Password)
+        if (AuthService.Login(loginModel.Email, loginModel.Password, admin))
         {
-            AuthService.SignIn();
             successMessage = "Login successfully";
             error = null;
         }
@@ -59,7 +57,11 @@ else
 
     private class LoginModel
     {
+        [System.ComponentModel.DataAnnotations.Required]
+        [System.ComponentModel.DataAnnotations.EmailAddress]
         public string Email { get; set; } = string.Empty;
+
+        [System.ComponentModel.DataAnnotations.Required]
         public string Password { get; set; } = string.Empty;
     }
 }

--- a/eStore/Components/Pages/Login.razor
+++ b/eStore/Components/Pages/Login.razor
@@ -12,7 +12,7 @@
 }
 else
 {
-    <EditForm Model="loginModel" OnValidSubmit="HandleLogin">
+    <EditForm Model="loginModel" OnValidSubmit="HandleLogin" FormName="adminLogin">
         <DataAnnotationsValidator />
         @if (!string.IsNullOrEmpty(error))
         {

--- a/eStore/Components/Pages/Login.razor
+++ b/eStore/Components/Pages/Login.razor
@@ -7,7 +7,7 @@
 
 @if (AuthService.IsLoggedIn)
 {
-    <p>You are logged in.</p>
+    <p class="text-success">@successMessage</p>
     <button class="btn btn-secondary" @onclick="Logout">Logout</button>
 }
 else
@@ -33,18 +33,22 @@ else
 @code {
     private LoginModel loginModel = new();
     private string? error;
+    private string successMessage = string.Empty;
 
     private void HandleLogin()
     {
         var admin = AdminOptions.Value;
-        if (loginModel.Email == admin.Email && loginModel.Password == admin.Password)
+        if (string.Equals(loginModel.Email?.Trim(), admin.Email, System.StringComparison.OrdinalIgnoreCase)
+            && loginModel.Password == admin.Password)
         {
             AuthService.SignIn();
-            Navigation.NavigateTo("/");
+            successMessage = "Login successfully";
+            error = null;
         }
         else
         {
             error = "Invalid credentials";
+            successMessage = string.Empty;
         }
     }
 

--- a/eStore/Components/_Imports.razor
+++ b/eStore/Components/_Imports.razor
@@ -8,3 +8,4 @@
 @using Microsoft.JSInterop
 @using eStore
 @using eStore.Components
+@using System.ComponentModel.DataAnnotations

--- a/eStore/Program.cs
+++ b/eStore/Program.cs
@@ -11,6 +11,9 @@ builder.Services.AddRazorComponents()
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
+builder.Services.Configure<AdminAccount>(builder.Configuration.GetSection("AdminAccount"));
+builder.Services.AddSingleton<AdminAuthService>();
+
 
 var app = builder.Build();
 

--- a/eStore/Program.cs
+++ b/eStore/Program.cs
@@ -12,7 +12,7 @@ builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
 builder.Services.Configure<AdminAccount>(builder.Configuration.GetSection("AdminAccount"));
-builder.Services.AddSingleton<AdminAuthService>();
+builder.Services.AddScoped<AdminAuthService>();
 
 
 var app = builder.Build();

--- a/eStore/appsettings.json
+++ b/eStore/appsettings.json
@@ -9,4 +9,9 @@
     }
   },
   "AllowedHosts": "*"
+  ,
+  "AdminAccount": {
+    "Email": "admin@estore.com",
+    "Password": "admin@@"
+  }
 }


### PR DESCRIPTION
## Summary
- store an admin account in `appsettings.json`
- create `AdminAccount` and `AdminAuthService` for simple authentication
- add a login page that checks credentials against appsettings
- register admin services in `Program.cs`
- link the login page in the navigation menu

## Testing
- `dotnet build Asm03Solution.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f66fcb654832d99e0faad5f313e5d