### PR TITLE
Add database-backed login

### DIFF
--- a/DataAccess/Repositories/IMemberRepository.cs
+++ b/DataAccess/Repositories/IMemberRepository.cs
@@ -6,6 +6,7 @@ namespace DataAccess.Repositories
     {
         IEnumerable<Member> GetAll();
         Member? GetById(int id);
+        Member? GetByEmailAndPassword(string email, string password);
         void Add(Member member);
         void Update(Member member);
         void Delete(Member member);

--- a/DataAccess/Repositories/MemberRepository.cs
+++ b/DataAccess/Repositories/MemberRepository.cs
@@ -16,6 +16,11 @@ namespace DataAccess.Repositories
 
         public Member? GetById(int id) => _context.Members.Find(id);
 
+        public Member? GetByEmailAndPassword(string email, string password) =>
+            _context.Members.AsNoTracking()
+                .SingleOrDefault(m => m.Email.Equals(email, System.StringComparison.OrdinalIgnoreCase)
+                    && m.Password == password);
+
         public void Add(Member member) => _context.Members.Add(member);
 
         public void Update(Member member) => _context.Members.Update(member);

--- a/eStore/AdminAuthService.cs
+++ b/eStore/AdminAuthService.cs
@@ -1,18 +1,28 @@
+using DataAccess.Repositories;
+
 namespace eStore
 {
     public class AdminAuthService
     {
+        private readonly IMemberRepository _memberRepository;
+
+        public AdminAuthService(IMemberRepository memberRepository)
+        {
+            _memberRepository = memberRepository;
+        }
+
         public bool IsLoggedIn { get; private set; }
         public event Action? OnChange;
 
         private void NotifyStateChanged() => OnChange?.Invoke();
 
-        public bool Login(string email, string password, AdminAccount account)
+        public bool Login(string email, string password)
         {
             var trimmedEmail = email.Trim();
             var trimmedPassword = password.Trim();
-            if (string.Equals(trimmedEmail, account.Email, System.StringComparison.OrdinalIgnoreCase)
-                && trimmedPassword == account.Password)
+
+            var member = _memberRepository.GetByEmailAndPassword(trimmedEmail, trimmedPassword);
+            if (member != null)
             {
                 IsLoggedIn = true;
                 NotifyStateChanged();

--- a/eStore/Components/Pages/Login.razor
+++ b/eStore/Components/Pages/Login.razor
@@ -1,6 +1,5 @@
 @page "/login"
 @rendermode InteractiveServer
-@inject Microsoft.Extensions.Options.IOptions<eStore.AdminAccount> AdminOptions
 @inject eStore.AdminAuthService AuthService
 @inject Microsoft.AspNetCore.Components.NavigationManager Navigation
 
@@ -43,11 +42,10 @@ else
 
     private void HandleLogin()
     {
-        var admin = AdminOptions.Value;
         var email = loginModel.Email?.Trim();
         var password = loginModel.Password?.Trim();
 
-        if (AuthService.Login(email, password, admin))
+        if (AuthService.Login(email, password))
         {
             successMessage = "Login successful.";
             error = null;


### PR DESCRIPTION
## Summary
- enable database lookup for login
- adjust login page to use new method

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6870bb8c4c00832d9e4955b1c3ad04f4