### PR TITLE
Fix SignalR connection for members

### DIFF
--- a/eStore/Components/Pages/Orders.razor
+++ b/eStore/Components/Pages/Orders.razor
@@ -127,19 +127,16 @@ else
 
         await LoadData();
 
-        if (isAdmin)
-        {
-            hubConnection = new HubConnectionBuilder()
-                .WithUrl(Navigation.ToAbsoluteUri("/orderHub"))
-                .WithAutomaticReconnect()
-                .Build();
+        hubConnection = new HubConnectionBuilder()
+            .WithUrl(Navigation.ToAbsoluteUri("/orderHub"))
+            .WithAutomaticReconnect()
+            .Build();
 
-            hubConnection.On<OrderDto>("OrderCreated", _ => InvokeAsync(LoadData));
-            hubConnection.On<OrderDto>("OrderUpdated", _ => InvokeAsync(LoadData));
-            hubConnection.On<int>("OrderDeleted", _ => InvokeAsync(LoadData));
+        hubConnection.On<OrderDto>("OrderCreated", _ => InvokeAsync(LoadData));
+        hubConnection.On<OrderDto>("OrderUpdated", _ => InvokeAsync(LoadData));
+        hubConnection.On<int>("OrderDeleted", _ => InvokeAsync(LoadData));
 
-            await hubConnection.StartAsync();
-        }
+        await hubConnection.StartAsync();
     }
 
     protected override void OnAfterRender(bool firstRender)


### PR DESCRIPTION
## Summary
- connect to OrderHub for all authenticated users
- remove admin-only check when initializing SignalR connection

## Testing
- `dotnet restore`
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6874a0581f48832db29e22f2a182fe72